### PR TITLE
Disable analysis/metrics in generated files

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -14,12 +14,16 @@ analyzer:
     implicit-dynamic: false
   exclude:
     - example/**
+    - "**/*.g.dart"
+    - "**/*.freezed.dart"
   plugins:
     - dart_code_metrics
 
 dart_code_metrics:
   exclude:
     - example/**
+    - "**/*.g.dart"
+    - "**/*.freezed.dart"
   rules:
     - avoid-nested-conditional-expressions:
         acceptable-level: 3


### PR DESCRIPTION
This disables analysis of code in generated files with .g.dart or .freezed.dart suffixes.